### PR TITLE
Fixes #16. Added additional check for special case =/ at the end of url.

### DIFF
--- a/rubrikcdm/client.go
+++ b/rubrikcdm/client.go
@@ -200,13 +200,16 @@ func apiVersionValidation(apiVersion string) bool {
 	return false
 }
 
-// endpointValidation validates that the endpoint provided in the Base API functions starts with a / but does not end with one.
+// endpointValidation validates that the endpoint provided in the Base API functions starts with a / but does not end with one except if preceded by a =
 func endpointValidation(apiEndpoint string) string {
 
 	if string(apiEndpoint[0]) != "/" {
 		return "errorStart"
 	} else if string(apiEndpoint[len(apiEndpoint)-1]) == "/" {
-		return "errorEnd"
+
+		if string(apiEndpoint[len(apiEndpoint)-2]) != "=" { // accounting for exeption =/
+			return "errorEnd"
+		}
 	}
 	return "success"
 }


### PR DESCRIPTION
# Description

Added additional check to account for special case =/ at the end of url. In this case no error will be thrown.

## Related Issue

Related to #16 .

## Motivation and Context

Currently all urls ending with / throw an exception. However this is not accurate in all cases. An example is /fileset/snapshot/5c39cd8b-7ba9-4e19-8694-1ac17e238050/browse?path=/ .

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-go/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
