### PR TITLE
Allow for API Token Authorization

### DIFF
--- a/rubrikcdm/client.go
+++ b/rubrikcdm/client.go
@@ -46,6 +46,7 @@ type Credentials struct {
 	NodeIP   string
 	Username string
 	Password string
+	APIToken string
 }
 
 // Connect initializes a new API client based on manually provided Rubrik cluster credentials. When possible,
@@ -56,6 +57,18 @@ func Connect(nodeIP, username, password string) *Credentials {
 		NodeIP:   nodeIP,
 		Username: username,
 		Password: password,
+	}
+
+	return client
+}
+
+// TokenConnect initializes a new API client based on manually provided Rubrik cluster API token. When possible,
+// the Rubrik API token should not be stored as plain text in your .go file. ConnectEnv() can be used
+// as a safer alternative.
+func TokenConnect(nodeIP, token string) *Credentials {
+	client := &Credentials{
+		NodeIP:   nodeIP,
+		APIToken: token,
 	}
 
 	return client
@@ -135,6 +148,8 @@ func (c *Credentials) commonAPI(callType, apiVersion, apiEndpoint string, config
 	}
 	if len(c.Username) != 0 {
 		request.SetBasicAuth(c.Username, c.Password)
+	} else {
+		request.Header.Add("Authorization", "Bearer "+c.APIToken)
 	}
 
 	request.Header.Set("Content-Type", "application/json")


### PR DESCRIPTION
# Description

I added the code for allowing authorization via API Token to my environment and it has been working fine. I prefer authenticating this way with it set in my environment variables.

## Related Issue

I found this open issue for supporting API tokens:
https://github.com/rubrikinc/rubrik-sdk-for-go/issues/40

## Motivation and Context

Why is this change required? What problem does it solve?
Allows for authenticating using an API token.

## How Has This Been Tested?

* I have tested this in my environment for a week now. Below is the sample code for calling my API token via environment variable.
nodeIp := os.Getenv("rubrik_cdm_node_ip")
token := os.Getenv("rubrik_api_token")
rubrik := rubrikcdm.TokenConnect(nodeIp, token)

## Screenshots (if appropriate):

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-go/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
