### PR TITLE
Add support for bootstrapping of CCES clusters

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
-module github.com/rubrikinc/rubrik-sdk-for-go
+module rubrikcdm
 
-go 1.14
+go 1.19
 
-require github.com/mitchellh/mapstructure v1.3.3
+require github.com/mitchellh/mapstructure v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/mitchellh/mapstructure v1.3.3 h1:SzB1nHZ2Xi+17FP0zVQBHIZqvwRN9408fJO8h+eeNA8=
-github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
+github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/rubrikcdm/client.go
+++ b/rubrikcdm/client.go
@@ -76,13 +76,13 @@ func ConnectAPIToken(nodeIP, apiToken string) *Credentials {
 // ConnectEnv is the preferred method to initialize a new API client by attempting to read the
 // following environment variables:
 //
-//  rubrik_cdm_node_ip
+//	rubrik_cdm_node_ip
 //
-//  rubrik_cdm_token
+//	rubrik_cdm_token
 //
-//  rubrik_cdm_username
+//	rubrik_cdm_username
 //
-//  rubrik_cdm_password
+//	rubrik_cdm_password
 //
 // rubrik_cdm_token will always take precedence over rubrik_cdm_username and rubrik_cdm_password
 func ConnectEnv() (*Credentials, error) {
@@ -164,7 +164,7 @@ func (c *Credentials) commonAPI(callType, apiVersion, apiEndpoint string, config
 	case "DELETE":
 		request, _ = http.NewRequest(callType, requestURL, nil)
 	case "JOB_STATUS":
-		// Overwrite the default requstURL with the job status url and convert to string
+		// Overwrite the default requestURL with the job status url and convert to string
 		requestURL = config.(string)
 		request, _ = http.NewRequest("GET", requestURL, nil)
 	}
@@ -248,7 +248,7 @@ func endpointValidation(apiEndpoint string) string {
 		return "errorStart"
 	} else if string(apiEndpoint[len(apiEndpoint)-1]) == "/" {
 
-		if string(apiEndpoint[len(apiEndpoint)-2]) != "=" { // accounting for exeption =/
+		if string(apiEndpoint[len(apiEndpoint)-2]) != "=" { // accounting for exemption =/
 			return "errorEnd"
 		}
 	}

--- a/rubrikcdm/cloud.go
+++ b/rubrikcdm/cloud.go
@@ -307,7 +307,7 @@ type CloudOn struct {
 // AddAWSNativeAccount enables the management and protection of Amazon Elastic Compute Cloud (Amazon EC2) instances. The "regionalBoltNetworkConfigs"
 // should be a list of dictionaries in the following format:
 //
-// 	usEast1 := map[string]string{}
+//	usEast1 := map[string]string{}
 //	usEast1["region"] = "us-east-1"
 //	usEast1["region"] = "us-east-1"
 //	usEast1["region"] = "us-east-1"
@@ -323,8 +323,11 @@ type CloudOn struct {
 //	eu-west-2, eu-west-3, us-west-1, us-east-1, us-east-2, and us-west-2.
 //
 // The function will return one of the following:
+//
 //	No change required. Cloud native source with access key '{awsAccessKey}' is already configured on the Rubrik cluster.
+//
 // //
+//
 //	The full API response for POST /internal/aws/account.
 func (c *Credentials) AddAWSNativeAccount(awsAccountName, awsAccessKey, awsSecretKey string, awsRegions []string, regionalBoltNetworkConfigs interface{}, timeout ...int) (interface{}, error) {
 
@@ -690,8 +693,8 @@ func (c *Credentials) ExportEC2Instance(instanceID, exportedInstanceName, instan
 
 }
 
-// RemoveAWSAccount deletes the specific AWS account from the Rubrik clsuter and waits for the job to complete before returning the JobStatus API response.
-func (c *Credentials) RemoveAWSAccount(awsAccountName string, deleteExsitingSnapshots bool, timeout ...int) (interface{}, error) {
+// RemoveAWSAccount deletes the specific AWS account from the Rubrik cluster and waits for the job to complete before returning the JobStatus API response.
+func (c *Credentials) RemoveAWSAccount(awsAccountName string, deleteExistingSnapshots bool, timeout ...int) (interface{}, error) {
 
 	httpTimeout := httpTimeout(timeout)
 
@@ -700,7 +703,7 @@ func (c *Credentials) RemoveAWSAccount(awsAccountName string, deleteExsitingSnap
 		return nil, err
 	}
 
-	deleteAPIRequest, err := c.Delete("internal", fmt.Sprintf("/aws/account/%s?delete_existing_snapshots=%t", awsAccountSummary.ID, deleteExsitingSnapshots), httpTimeout)
+	deleteAPIRequest, err := c.Delete("internal", fmt.Sprintf("/aws/account/%s?delete_existing_snapshots=%t", awsAccountSummary.ID, deleteExistingSnapshots), httpTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -721,23 +724,24 @@ func (c *Credentials) RemoveAWSAccount(awsAccountName string, deleteExsitingSnap
 }
 
 // UpdateAWSNativeAccount updates the configuration of a AWS Native account. The following values, from PATCH /internal/aws/account/{id} are options for the config:
-//  {
-//   "name": "string",
-//   "accessKey": "string",
-//   "secretKey": "string",
-//   "regions": [
-//     "string"
-//   ],
-//   "regionalBoltNetworkConfigs": [
-//     {
-//       "region": "string",
-//       "vNetId": "string",
-//       "subnetId": "string",
-//       "securityGroupId": "string"
-//     }
-//   ],
-//   "disasterRecoveryArchivalLocationId": "string"
-// }
+//
+//	 {
+//	  "name": "string",
+//	  "accessKey": "string",
+//	  "secretKey": "string",
+//	  "regions": [
+//	    "string"
+//	  ],
+//	  "regionalBoltNetworkConfigs": [
+//	    {
+//	      "region": "string",
+//	      "vNetId": "string",
+//	      "subnetId": "string",
+//	      "securityGroupId": "string"
+//	    }
+//	  ],
+//	  "disasterRecoveryArchivalLocationId": "string"
+//	}
 func (c *Credentials) UpdateAWSNativeAccount(archiveName string, config map[string]interface{}, timeout ...int) (*UpdateAWSNative, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -774,9 +778,10 @@ func (c *Credentials) UpdateAWSNativeAccount(archiveName string, config map[stri
 //	standard, standard_ia, and reduced_redundancy
 //
 // The function will return one of the following:
-//	- No change required. The '{archiveName}' archive location is already configured on the Rubrik cluster.
 //
-//	- The full API response for POST /internal/archive/object_store.
+//   - No change required. The '{archiveName}' archive location is already configured on the Rubrik cluster.
+//
+//   - The full API response for POST /internal/archive/object_store.
 func (c *Credentials) AWSS3CloudOutRSA(awsBucketName, storageClass, archiveName, awsRegion, awsAccessKey, awsSecretKey, rsaKey string, timeout ...int) (interface{}, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -825,7 +830,7 @@ func (c *Credentials) AWSS3CloudOutRSA(awsBucketName, storageClass, archiveName,
 	config["objectStoreType"] = "S3"
 	config["pemFileContent"] = rsaKey
 
-	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotence check
+	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotent check
 	redactedConfig := map[string]interface{}{}
 	redactedConfig["name"] = archiveName
 	redactedConfig["bucket"] = strings.ToLower(awsBucketName)
@@ -897,7 +902,7 @@ func (c *Credentials) CloudObjectStore(timeout ...int) (*CloudObjectStore, error
 
 }
 
-// AWSAccountSummary retrives all information from an AWS Native Account.
+// AWSAccountSummary retrieves all information from an AWS Native Account.
 func (c *Credentials) AWSAccountSummary(awsAccountName string, timeout ...int) (*CurrentAWSAccountID, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -997,54 +1002,55 @@ func (c *Credentials) RemoveArchiveLocation(archiveName string, timeout ...int) 
 }
 
 // UpdateCloudArchiveLocation updates the configuration of a the Cloud Archival Location. The following values, from PATCH /internal/object_store/{id} are options for the config:
-//  {
-//     "name": "string",
-//     "accessKey": "string",
-//     "secretKey": "string",
-//     "endpoint": "string",
-//     "numBuckets": 0,
-//     "isComputeEnabled": true,
-//     "isConsolidationEnabled": true,
-//     "defaultComputeNetworkConfig": {
-//       "subnetId": "string",
-//       "vNetId": "string",
-//       "securityGroupId": "string",
-//       "resourceGroupId": "string"
-//     },
-//     "storageClass": "string",
-//     "glacierConfig": {
-//       "retrievalTier": "BulkRetrieval",
-//       "vaultLockPolicy": {
-//         "fileLockPeriodInDays": 0
-//       }
-//     },
-//     "azureComputeSummary": {
-//       "tenantId": "string",
-//       "subscriptionId": "string",
-//       "clientId": "string",
-//       "region": "string",
-//       "generalPurposeStorageAccountName": "string",
-//       "containerName": "string",
-//       "environment": "AZURE"
-//     },
-//     "azureComputeSecret": {
-//     "  clientSecret": "string"
-//     },
-//     "archivalProxyConfig": {
-//       "protocol": "HTTP",
-//       "proxyServer": "string",
-//       "portNumber": 0,
-//       "userName": "string",
-//       "password": "string"
-//     },
-//     "computeProxyConfig": {
-//       "protocol": "HTTP",
-//       "proxyServer": "string",
-//       "portNumber": 0,
-//       "userName": "string",
-//       "password": "string"
-//     }
-//   }
+//
+//	{
+//	   "name": "string",
+//	   "accessKey": "string",
+//	   "secretKey": "string",
+//	   "endpoint": "string",
+//	   "numBuckets": 0,
+//	   "isComputeEnabled": true,
+//	   "isConsolidationEnabled": true,
+//	   "defaultComputeNetworkConfig": {
+//	     "subnetId": "string",
+//	     "vNetId": "string",
+//	     "securityGroupId": "string",
+//	     "resourceGroupId": "string"
+//	   },
+//	   "storageClass": "string",
+//	   "glacierConfig": {
+//	     "retrievalTier": "BulkRetrieval",
+//	     "vaultLockPolicy": {
+//	       "fileLockPeriodInDays": 0
+//	     }
+//	   },
+//	   "azureComputeSummary": {
+//	     "tenantId": "string",
+//	     "subscriptionId": "string",
+//	     "clientId": "string",
+//	     "region": "string",
+//	     "generalPurposeStorageAccountName": "string",
+//	     "containerName": "string",
+//	     "environment": "AZURE"
+//	   },
+//	   "azureComputeSecret": {
+//	   "  clientSecret": "string"
+//	   },
+//	   "archivalProxyConfig": {
+//	     "protocol": "HTTP",
+//	     "proxyServer": "string",
+//	     "portNumber": 0,
+//	     "userName": "string",
+//	     "password": "string"
+//	   },
+//	   "computeProxyConfig": {
+//	     "protocol": "HTTP",
+//	     "proxyServer": "string",
+//	     "portNumber": 0,
+//	     "userName": "string",
+//	     "password": "string"
+//	   }
+//	 }
 func (c *Credentials) UpdateCloudArchiveLocation(archiveName string, config map[string]interface{}, timeout ...int) (*UpdateArchiveLocations, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -1101,9 +1107,10 @@ func (c *Credentials) UpdateCloudArchiveLocation(archiveName string, config map[
 //	standard, standard_ia, and reduced_redundancy
 //
 // The function will return one of the following:
-//	- No change required. The '{archiveName}' archive location is already configured on the Rubrik cluster.
 //
-//	- The full API response for POST /internal/archive/object_store/{archiveID}
+//   - No change required. The '{archiveName}' archive location is already configured on the Rubrik cluster.
+//
+//   - The full API response for POST /internal/archive/object_store/{archiveID}
 func (c *Credentials) AWSS3CloudOutKMS(awsBucketName, storageClass, archiveName, awsRegion, awsAccessKey, awsSecretKey, kmsMasterKeyID string, timeout ...int) (interface{}, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -1152,7 +1159,7 @@ func (c *Credentials) AWSS3CloudOutKMS(awsBucketName, storageClass, archiveName,
 	config["objectStoreType"] = "S3"
 	config["kmsMasterKeyId"] = kmsMasterKeyID
 
-	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotence check
+	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotent check
 	redactedConfig := map[string]interface{}{}
 	redactedConfig["name"] = archiveName
 	redactedConfig["bucket"] = strings.ToLower(awsBucketName)
@@ -1202,9 +1209,10 @@ func (c *Credentials) AWSS3CloudOutKMS(awsBucketName, storageClass, archiveName,
 // and then launch that AMI into an Elastic Compute Cloud (EC2) instance on an Amazon Virtual Private Cloud (VPC).
 //
 // The function will return one of the following:
-//	- No change required. The '{archiveName}' archive location is already configured for CloudOn.
 //
-//	- The full API response for PATCH /internal/archive/object_store.
+//   - No change required. The '{archiveName}' archive location is already configured for CloudOn.
+//
+//   - The full API response for PATCH /internal/archive/object_store.
 func (c *Credentials) AWSS3CloudOn(archiveName, vpcID, subnetID, securityGroupID string, timeout ...int) (*CloudOn, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -1256,9 +1264,10 @@ func (c *Credentials) AWSS3CloudOn(archiveName, vpcID, subnetID, securityGroupID
 //	default, china, germany, and government
 //
 // The function will return one of the following:
-//	- No change required. The '{archiveName}' archive location is already configured on the Rubrik cluster.
 //
-//	- The full API response for POST /internal/archive/object_store.
+//   - No change required. The '{archiveName}' archive location is already configured on the Rubrik cluster.
+//
+//   - The full API response for POST /internal/archive/object_store.
 func (c *Credentials) AzureCloudOut(container, azureAccessKey, storageAccountName, archiveName, instanceType, rsaKey string, timeout ...int) (interface{}, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -1290,7 +1299,7 @@ func (c *Credentials) AzureCloudOut(container, azureAccessKey, storageAccountNam
 		config["endpoint"] = "core.chinacloudapi.cn"
 	}
 
-	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotence check
+	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotent check
 	redactedConfig := map[string]interface{}{}
 	redactedConfig["objectStoreType"] = "Azure"
 	redactedConfig["name"] = archiveName
@@ -1347,14 +1356,16 @@ func (c *Credentials) AzureCloudOut(container, azureAccessKey, storageAccountNam
 // of the associated virtual machine on the Microsoft Azure cloud platform.
 //
 // Valid "region" choices are:
-// 	westus, westus2, centralus, eastus, eastus2, northcentralus, southcentralus, westcentralus, canadacentral, canadaeast, brazilsouth,
+//
+//	westus, westus2, centralus, eastus, eastus2, northcentralus, southcentralus, westcentralus, canadacentral, canadaeast, brazilsouth,
 //	northeurope, westeurope, uksouth, ukwest, eastasia, southeastasia, japaneast, japanwest, australiaeast, australiasoutheast, centralindia,
 //	southindia, westindia, koreacentral, koreasouth
 //
 // The function will return one of the following:
-//	- No change required. The '{archiveName}' archive location is already configured for CloudOn.
 //
-//	- The full API response for PATCH /internal/archive/object_store.
+//   - No change required. The '{archiveName}' archive location is already configured for CloudOn.
+//
+//   - The full API response for PATCH /internal/archive/object_store.
 func (c *Credentials) AzureCloudOn(archiveName, container, storageAccountName, applicationID, applicationKey, directoryID, region, virtualNetworkID, subnetName, securityGroupID string, timeout ...int) (*CloudOn, error) {
 
 	httpTimeout := httpTimeout(timeout)
@@ -1414,7 +1425,7 @@ func (c *Credentials) AzureCloudOn(archiveName, container, storageAccountName, a
 	config["defaultComputeNetworkConfig"].(map[string]string)["securityGroupId"] = securityGroupID
 	config["defaultComputeNetworkConfig"].(map[string]string)["resourceGroupId"] = strings.Split(virtualNetworkID, "/")[4]
 
-	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotence check
+	// Create a simplified config that only includes the values returned by Rubrik that can be used for idempotent check
 	redactedConfig := map[string]interface{}{}
 	redactedConfig["name"] = archiveName
 	redactedConfig["objectStoreType"] = "Azure"

--- a/rubrikcdm/cluster.go
+++ b/rubrikcdm/cluster.go
@@ -203,6 +203,7 @@ func (c *Credentials) ClusterBootstrapStatus(timeout ...int) (bool, error) {
 // supported "objectType"
 //
 // The function will return one of the following:
+//
 //	No change required. The End User '{endUser}' is already authorized to interact with the '{objectName}' VM.
 //
 //	The full API response for POST /internal/authorization/role/end_user
@@ -272,12 +273,13 @@ func (c *Credentials) EndUserAuthorization(objectName, endUser, objectType strin
 //
 // Valid timezone choices are:
 //
-// 	America/Anchorage, America/Araguaina, America/Barbados, America/Chicago, America/Denver, America/Los_Angeles America/Mexico_City, America/New_York,
+//	America/Anchorage, America/Araguaia, America/Barbados, America/Chicago, America/Denver, America/Los_Angeles America/Mexico_City, America/New_York,
 //	America/Noronha, America/Phoenix, America/Toronto, America/Vancouver, Asia/Bangkok, Asia/Dhaka, Asia/Dubai, Asia/Hong_Kong, Asia/Karachi, Asia/Kathmandu,
 //	Asia/Kolkata, Asia/Magadan, Asia/Singapore, Asia/Tokyo, Atlantic/Cape_Verde, Australia/Perth, Australia/Sydney, Europe/Amsterdam, Europe/Athens,
 //	Europe/London, Europe/Moscow, Pacific/Auckland, Pacific/Honolulu, Pacific/Midway, or UTC.
 //
 // The function will return one of the following:
+//
 //	No change required. The Rubrik cluster is already configured with '{timezone}' as it's timezone.
 //
 //	The full API response for POST /v1/cluster/me
@@ -357,6 +359,7 @@ func (c *Credentials) ConfigureTimezone(timezone string, timeout ...int) (*Clust
 // ConfigureNTP provides the connection information for the NTP servers used for time synchronization.
 //
 // The function will return one of the following:
+//
 //	No change required. The NTP server(s) {ntpServers} has already been added to the Rubrik cluster.
 //
 //	The full API response for POST /internal/cluster/me/ntp_server
@@ -414,6 +417,7 @@ func (c *Credentials) ConfigureNTP(ntpServers []string, timeout ...int) (*Status
 //	UDP, TCP
 //
 // The function will return one of the following:
+//
 //	No change required. The Rubrik cluster is already configured to use the syslog server '{syslogIP}' on port '{port}' using the '{protocol}' protocol.
 //
 //	The full API response for POST /internal/syslog
@@ -486,6 +490,7 @@ func (c *Credentials) ConfigureSyslog(syslogIP, protocol string, port float64, t
 // ConfigureDNSServers provides the connection information for the DNS Servers used by the Rubrik cluster.
 //
 // The function will return one of the following:
+//
 //	No change required. The Rubrik cluster is already configured with the provided DNS servers.
 //
 //	The full API response for POST /internal/cluster/me/dns_nameserver
@@ -521,6 +526,7 @@ func (c *Credentials) ConfigureDNSServers(serverIP []string, timeout ...int) (*S
 // ConfigureSearchDomain provides the connection information for the DNS search domains used by the Rubrik cluster.
 //
 // The function will return one of the following:
+//
 //	No change required. The Rubrik cluster is already configured with the provided DNS search domains.
 //
 //	The full API response for POST /internal/cluster/me/dns_search_domain
@@ -560,6 +566,7 @@ func (c *Credentials) ConfigureSearchDomain(searchDomain []string, timeout ...in
 //	NONE, SSL, and STARTTLS
 //
 // The function will return one of the following:
+//
 //	No change required. The Rubrik cluster is already configured with the provided SMTP settings.
 //
 //	The full API response for POST /internal/smtp_instance
@@ -641,6 +648,7 @@ func (c *Credentials) ConfigureSMTPSettings(hostname, fromEmail, smtpUsername, s
 // efficiently switch network traffic using Virtual Local Area Networks. The ips map should be in a {nodeName:IP} format.
 //
 // The function will return one of the following:
+//
 //	No change required. The Rubrik cluster is already configured with the provided VLAN information.
 //
 //	The full API response for POST /internal/cluster/me/vlan
@@ -692,6 +700,7 @@ func (c *Credentials) ConfigureVLAN(netmask string, vlan int, ips map[string]str
 // AddvCenter connects to the Rubrik cluster to a new vCenter instance.
 //
 // The function will return one of the following:
+//
 //	No change required. The vCenter '{vcenterIP}' has already been added to the Rubrik cluster.
 //
 //	The full API response for POST /v1/VMware/vcenter
@@ -745,6 +754,7 @@ func (c *Credentials) AddvCenter(vCenterIP, vCenterUsername, vCenterPassword str
 // AddvCenterWithCert connects to the Rubrik cluster to a new vCenter instance using a CA certificate.
 //
 // The function will return one of the following:
+//
 //	No change required. The vCenter '{vcenterIP}' has already been added to the Rubrik cluster.
 //
 //	The full API response for POST /v1/VMware/vcenter

--- a/rubrikcdm/data_management.go
+++ b/rubrikcdm/data_management.go
@@ -3,7 +3,8 @@
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License prop
-//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -63,6 +64,7 @@ type Cluster struct {
 // Valid "objectType" choices are:
 //
 //	vmware, sla, vmwareHost, physicalHost, filesetTemplate, managedVolume, vcenter, and ec2.
+//
 // When the "objectType" is "ec2", the objectName should correspond to the AWS Instance ID.
 func (c *Credentials) ObjectID(objectName, objectType string, timeout int, hostOS ...string) (string, error) {
 
@@ -109,7 +111,7 @@ func (c *Credentials) ObjectID(objectName, objectType string, timeout int, hostO
 
 			}
 		} else if len(hostOS) == 0 {
-			return "", errors.New("You must provide the Fileset Tempalte OS type")
+			return "", errors.New("You must provide the Fileset Template OS type")
 		}
 		objectSummaryAPIVersion = "v1"
 		objectSummaryAPIEndpoint = fmt.Sprintf("/fileset_template?primary_cluster_id=local&operating_system_type=%s&name=%s", hostOperatingSystem, objectName)
@@ -168,6 +170,7 @@ func (c *Credentials) ObjectID(objectName, objectType string, timeout int, hostO
 // use "do not protect" as the "slaName". To assign the selected object to the SLA of the next higher level object, use "clear" as the "slaName".
 //
 // The function will return one of the following:
+//
 //	No change required. The vSphere VM '{objectName}' is already assigned to the '{slaName}' SLA Domain.
 //
 //	The full API response for POST /internal/sla_domain/{slaID}/assign.
@@ -269,6 +272,7 @@ func (c *Credentials) AssignSLA(objectName, objectType, slaName string, timeout 
 // ended will be part of its snapshot.
 //
 // The function will return one of the following:
+//
 //	No change required. The Managed Volume '{name}' is already in a writeable state.
 //
 //	The full API response for POST /internal/managed_volume/{managedVolumeID}/begin_snapshot
@@ -310,6 +314,7 @@ func (c *Credentials) BeginManagedVolumeSnapshot(name string, timeout ...int) (*
 // EndManagedVolumeSnapshot closes a managed volume for writes. A snapshot will be created containing all writes since the last begin snapshot call.
 //
 // The function will return one of the following:
+//
 //	No change required. The Managed Volume '{name}' is already in a read-only state.
 //
 //	The full API response for POST /internal/managed_volume/{managedVolumeID}/end_snapshot
@@ -404,6 +409,7 @@ func (c *Credentials) GetSLAObjects(slaName, objectType string, timeout ...int) 
 // PauseSnapshot suspends all snapshot activity for the provided object. The only "objectType" current supported is vmware.
 //
 // The function will return one of the following:
+//
 //	No change required. The '{objectName}' '{objectType}' is already paused.
 //
 //	The full API response for POST /internal/vmware/vm/{vmID}
@@ -458,6 +464,7 @@ func (c *Credentials) PauseSnapshot(objectName, objectType string, timeout ...in
 // ResumeSnapshot resumes all snapshot activity for the provided object. The only "objectType" currently supported is vmware.
 //
 // The function will return one of the following:
+//
 //	No change required. The '{objectName}' '{objectType}' is currently not paused.
 //
 //	The full API response for POST /internal/vmware/vm/{vmID}
@@ -513,6 +520,7 @@ func (c *Credentials) ResumeSnapshot(objectName, objectType string, timeout ...i
 // assigned SLA Domain for the snapshot use "current" for the slaName.
 //
 // The function will return:
+//
 //	The job status URL for the on-demand Snapshot
 func (c *Credentials) OnDemandSnapshotVM(objectName, objectType, slaName string, timeout ...int) (string, error) {
 
@@ -575,6 +583,7 @@ func (c *Credentials) OnDemandSnapshotVM(objectName, objectType, slaName string,
 //	Linux and Windows
 //
 // The function will return:
+//
 //	The job status URL for the on-demand Snapshot
 func (c *Credentials) OnDemandSnapshotPhysical(hostName, slaName, fileset, hostOS string, timeout ...int) (string, error) {
 
@@ -630,12 +639,12 @@ func (c *Credentials) OnDemandSnapshotPhysical(hostName, slaName, fileset, hostO
 	config := map[string]string{}
 	config["slaId"] = slaID
 
-	apiRequeset, err := c.Post("v1", fmt.Sprintf("/fileset/%s/snapshot", filesetID), config, httpTimeout)
+	apiRequest, err := c.Post("v1", fmt.Sprintf("/fileset/%s/snapshot", filesetID), config, httpTimeout)
 	if err != nil {
 		return "", err
 	}
 
-	return apiRequeset.(map[string]interface{})["links"].([]interface{})[0].(map[string]interface{})["href"].(string), nil
+	return apiRequest.(map[string]interface{})["links"].([]interface{})[0].(map[string]interface{})["href"].(string), nil
 }
 
 func (c *Credentials) DateTimeConversion(dateTime string, timeout ...int) (string, error) {
@@ -673,6 +682,7 @@ func (c *Credentials) DateTimeConversion(dateTime string, timeout ...int) (strin
 //	Linux and Windows
 //
 // The function will return:
+//
 //	The job status URL for file download job from a fileset backup
 func (c *Credentials) RecoverFileDownload(hostName, fileset, hostOS, filePath, dateTime string, timeout ...int) (string, error) {
 	httpTimeout := httpTimeout(timeout)

--- a/rubrikcdm/examples_test.go
+++ b/rubrikcdm/examples_test.go
@@ -317,6 +317,65 @@ func ExampleCredentials_Bootstrap() {
 
 }
 
+func ExampleCredentials_BootstrapAws() {
+
+	bootstrapNode := "192.168.102.100"
+	rubrik := rubrikcdm.Connect(bootstrapNode, "", "")
+
+	clusterName := "Go-SDK"
+	adminEmail := "gosdk@rubrikgosdk.lab"
+	adminPassword := "RubrikGoSDK"
+	managementGateway := "192.168.102.1"
+	managementSubnetMask := "255.255.255.0"
+	dnsSearchDomain := []string{"rubrikgosdk.lab"}
+	dnsNameServers := []string{"192.168.100.5", "192.168.100.6"}
+	ntpServers := []string{"192.168.100.5", "192.168.100.6"}
+	enableEncryption := false // set to false for a Cloud Cluster
+	bucketName := "s3-bucket-for-cces-aws"
+	waitForCompletion := true
+
+	nodeConfig := map[string]string{}
+	nodeConfig["CCESAWSNODE1"] = bootstrapNode
+	nodeConfig["CCESAWSNODE2"] = "192.168.102.101"
+	nodeConfig["CCESAWSNODE3"] = "192.168.102.102"
+
+	_, err := rubrik.BootstrapCcesAws(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask, dnsSearchDomain, dnsNameServers, ntpServers, nodeConfig, enableEncryption, bucketName, waitForCompletion)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}
+
+func ExampleCredentials_BootstrapAzure() {
+
+	bootstrapNode := "192.168.103.100"
+	rubrik := rubrikcdm.Connect(bootstrapNode, "", "")
+
+	clusterName := "Go-SDK"
+	adminEmail := "gosdk@rubrikgosdk.lab"
+	adminPassword := "RubrikGoSDK"
+	managementGateway := "192.168.103.1"
+	managementSubnetMask := "255.255.255.0"
+	dnsSearchDomain := []string{"rubrikgosdk.lab"}
+	dnsNameServers := []string{"192.168.100.5", "192.168.100.6"}
+	ntpServers := []string{"192.168.100.5", "192.168.100.6"}
+	enableEncryption := false // set to false for a Cloud Cluster
+	connectionString := "DefaultEndpointsProtocol=https;AccountName=storageaccountforccesazuregosdk;AccountKey=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890abcdefghijklm==;EndpointSuffix=core.windows.net"
+	containerName := "container-for-cces-azure-gosdk"
+	waitForCompletion := true
+
+	nodeConfig := map[string]string{}
+	nodeConfig["CCESAZURENODE1"] = bootstrapNode
+	nodeConfig["CCESAZURENODE2"] = "192.168.103.101"
+	nodeConfig["CCESAZURENODE3"] = "192.168.103.102"
+
+	_, err := rubrik.BootstrapCcesAzure(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask, dnsSearchDomain, dnsNameServers, ntpServers, nodeConfig, enableEncryption, connectionString, containerName, waitForCompletion)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+}
+
 func ExampleCredentials_ConfigureDNSServers() {
 	rubrik, err := rubrikcdm.ConnectEnv()
 

--- a/rubrikcdm/examples_test.go
+++ b/rubrikcdm/examples_test.go
@@ -692,7 +692,7 @@ func ExampleCredentials_AzureCloudOn() {
 	applicationID := os.Getenv("AZURE_APP_ID")
 	applicationKey := os.Getenv("AZURE_APP_KEY")
 
-	directoryID := os.Getenv("AZURE_DIRECTORTY_ID")
+	directoryID := os.Getenv("AZURE_DIRECTORY_ID")
 	region := "westus2"
 	virtualNetworkID := os.Getenv("AZURE_VNET_ID")
 	subnetName := os.Getenv("AZURE_SUBNET")

--- a/rubrikcdm/examples_test.go
+++ b/rubrikcdm/examples_test.go
@@ -27,12 +27,12 @@ func ExampleCredentials_ExportEC2Instance() {
 		log.Fatal(err)
 	}
 
-	instanceID := "i-0268174613c9404dc"
+	instanceID := "i-0123456789abcdefg"
 	exportInstanceName := "Go SDK"
 	instanceType := "m4.large"
 	awsRegion := "us-east-2"
-	subnetID := "subnet-0099d50dd9df9f088"
-	securityGroupID := "sg-082f435771cd7e4d1"
+	subnetID := "subnet-0123456789abcdefg"
+	securityGroupID := "sg-0123456789abcdefg"
 	dateTime := "04-09-2019 05:56 PM"
 	waitForCompletion := true
 
@@ -209,7 +209,7 @@ func ExampleCredentials_AddvCenter() {
 		log.Fatal(err)
 	}
 
-	vCenterIP := "demogosdk.lab"
+	vCenterIP := "vcsa.rubrikgosdk.lab"
 	vCenterUsername := "go"
 	vCenterPassword := "sdk"
 	vmLinking := true
@@ -226,7 +226,7 @@ func ExampleCredentials_AddvCenterWithCert() {
 		log.Fatal(err)
 	}
 
-	vCenterIP := "demogosdk.lab"
+	vCenterIP := "vcsa.rubrikgosdk.lab"
 	vCenterUsername := "go"
 	vCenterPassword := "sdk"
 	readcaCertificate, _ := ioutil.ReadFile("ca_cert")
@@ -245,9 +245,9 @@ func ExampleCredentials_ConfigureSMTPSettings() {
 		log.Fatal(err)
 	}
 
-	hostname := "smtp.GOSDK.lab"
+	hostname := "smtp.rubrikgosdk.lab"
 	port := 100
-	fromEmail := "gosdk@rubrik.com"
+	fromEmail := "gosdk@rubrikgosdk.lab"
 	username := "go"
 	password := "sdk"
 	encryption := "NONE"
@@ -264,7 +264,7 @@ func ExampleCredentials_ConfigureSearchDomain() {
 		log.Fatal(err)
 	}
 
-	searchDomains := []string{"gosdk.lab"}
+	searchDomains := []string{"rubrikgosdk.lab"}
 
 	searchDomainConfig, err := rubrik.ConfigureSearchDomain(searchDomains)
 	if err != nil {
@@ -290,25 +290,25 @@ func ExampleCredentials_ObjectID() {
 
 func ExampleCredentials_Bootstrap() {
 
-	bootstrapNode := "10.77.16.239"
+	bootstrapNode := "192.168.101.100"
 	rubrik := rubrikcdm.Connect(bootstrapNode, "", "")
 
 	clusterName := "Go-SDK"
-	adminEmail := "gosdk@rubrik.com"
+	adminEmail := "gosdk@rubrikgosdk.lab"
 	adminPassword := "RubrikGoSDK"
-	managementGateway := "10.77.16.1"
-	managementSubnetMask := "255.255.252.0"
-	dnsSearchDomain := []string{"gosdk.lab"}
-	dnsNameServers := []string{}
-	ntpServers := []string{"192.21.10.21", "192.21.10.22"}
+	managementGateway := "192.168.101.1"
+	managementSubnetMask := "255.255.255.0"
+	dnsSearchDomain := []string{"rubrikgosdk.lab"}
+	dnsNameServers := []string{"192.168.100.5", "192.168.100.6"}
+	ntpServers := []string{"192.168.100.5", "192.168.100.6"}
 	enableEncryption := true // set to false for a Cloud Cluster
 	waitForCompletion := true
 
 	nodeConfig := map[string]string{}
-	nodeConfig["RVM157S018901"] = bootstrapNode
-	nodeConfig["RVM157S018902"] = "10.77.16.56"
-	nodeConfig["RVM157S018903"] = "10.77.16.198"
-	nodeConfig["RVM157S018904"] = "10.77.16.81"
+	nodeConfig["RVM1234567890"] = bootstrapNode
+	nodeConfig["RVM1234567891"] = "192.168.101.101"
+	nodeConfig["RVM1234567892"] = "192.168.101.102"
+	nodeConfig["RVM1234567893"] = "192.168.101.103"
 
 	bootstrap, err := rubrik.Bootstrap(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask, dnsSearchDomain, dnsNameServers, ntpServers, nodeConfig, enableEncryption, waitForCompletion)
 	if err != nil {
@@ -379,7 +379,7 @@ func ExampleCredentials_BootstrapAzure() {
 func ExampleCredentials_ConfigureDNSServers() {
 	rubrik, err := rubrikcdm.ConnectEnv()
 
-	dnsServers := []string{"192.21.10.50", "192.21.10.51"}
+	dnsServers := []string{"192.168.100.5", "192.168.100.6"}
 
 	dnsConfig, err := rubrik.ConfigureDNSServers(dnsServers)
 	if err != nil {
@@ -393,7 +393,7 @@ func ExampleCredentials_ConfigureSyslog() {
 		log.Fatal(err)
 	}
 
-	syslogIP := "192.21.11.29"
+	syslogIP := "192.168.100.7"
 	syslogProtocol := "UDP"
 	syslogPort := 514
 
@@ -409,7 +409,7 @@ func ExampleCredentials_RegisterCluster() {
 		log.Fatal(err)
 	}
 
-	support_portal_username := "gosdk@rubrik.com"
+	support_portal_username := "gosdk@rubrikgosdk.lab"
 	support_portal_password := "GoDummyPassword"
 
 	register, err := rubrik.RegisterCluster(support_portal_username, support_portal_password)
@@ -424,7 +424,7 @@ func ExampleCredentials_ConfigureNTP() {
 		log.Fatal(err)
 	}
 
-	ntpServers := []string{"192.21.10.21", "192.21.10.22"}
+	ntpServers := []string{"192.168.100.5", "192.168.100.6"}
 
 	ntp, err := rubrik.ConfigureNTP(ntpServers)
 	if err != nil {
@@ -538,9 +538,9 @@ func ExampleCredentials_AddAWSNativeAccount() {
 
 	usEast1 := map[string]string{}
 	usEast1["region"] = "us-east-1"
-	usEast1["vNetId"] = "vpc-11a44968"
-	usEast1["subnetId"] = "subnet-3ac58e06"
-	usEast1["securityGroupId"] = "sg-9ba90ee5"
+	usEast1["vNetId"] = "vpc-01234567"
+	usEast1["subnetId"] = "subnet-01234567"
+	usEast1["securityGroupId"] = "sg-01234567"
 	boltConfig := []interface{}{usEast1}
 
 	addAWSNative, err := rubrik.AddAWSNativeAccount(awsAccountName, awsAccessKey, awsSecretKey, awsRegions, boltConfig)
@@ -555,7 +555,7 @@ func ExampleCredentials_RefreshvCenter() {
 		log.Fatal(err)
 	}
 
-	vcenter_hostname := "go.demo.lab"
+	vcenter_hostname := "vcsa.rubrikgosdk.lab"
 
 	refresh, err := rubrik.RefreshvCenter(vcenter_hostname)
 	if err != nil {
@@ -709,9 +709,9 @@ func ExampleCredentials_AWSS3CloudOn() {
 	}
 
 	archiveName := "AWS:S3:GoSDK"
-	vpcID := "vpc-28e32931"
-	subnetID := "subnet-3ae87e92"
-	securityGroupID := "sg-9ba32ff8"
+	vpcID := "vpc-01234567"
+	subnetID := "subnet-01234567"
+	securityGroupID := "sg-01234567"
 
 	awsCloudOn, err := rubrik.AWSS3CloudOn(archiveName, vpcID, subnetID, securityGroupID)
 	if err != nil {
@@ -770,7 +770,7 @@ func ExampleCredentials_RecoverFileDownload() {
 		log.Fatal(err)
 	}
 
-	hostName := "rubrik-sql01.hybrid-lab.local"
+	hostName := "rubrik-sql01rubrikgosdk.lab"
 	fileset := "fileset01"
 	hostOS := "Linux"
 	dateTime := "04-17-2020 12:49 PM"


### PR DESCRIPTION
# Description

Added support for bootstrapping CCES clusters. The new functions `BootstrapCcesAws` and `BootstrapCcesAzure` were added.

## Related Issue

Fixes #56 

## Motivation and Context

Needed to provide a way to bootstrap CCES clusters for downstream projects.

## How Has This Been Tested?

Spun up CCES nodes in AWS and Azure. Ran the `BootstrapCcesAws` and `BootstrapCcesAzure` functions and successfully bootstrapped the clusters. 

## Screenshots (if appropriate):

None

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-go/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
