### PR TITLE
Bootstrap CCES clusters and set NTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,3 +26,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - `ConnectEnv()` will not look for a configured `rubrik_cdm_token` environment variable
+
+## v1.0.4
+
+### Fixed
+- Prevent potential HTTP connection issues from occurring on long-running jobs
+
+## v1.1.0
+
+### Added
+
+- `BootstrapCcesAws()` will bootstrap a Cloud Cluster Elastic Storage in AWS
+- `BootstrapCcesAzure()` will bootstrap a Cloud Cluster Elastic Storage in Azure
+
+### Fixed
+
+- `Bootstrap()` fixed NTP code so that NTP will be updated properly on newer Rubrik clusters. This is a breaking change for Rubrik clusters older than v5.0.

--- a/rubrikcdm/client.go
+++ b/rubrikcdm/client.go
@@ -177,7 +177,7 @@ func (c *Credentials) commonAPI(callType, apiVersion, apiEndpoint string, config
 
 	request.Header.Set("Content-Type", "application/json")
 	request.Header.Set("Accept", "application/json")
-	request.Header.Set("User-Agent", "Rubrik Go SDK v1.0.2")
+	request.Header.Set("User-Agent", "Rubrik Go SDK v1.1.0")
 	request.Close = true
 
 	apiRequest, err := client.Do(request)

--- a/rubrikcdm/cluster.go
+++ b/rubrikcdm/cluster.go
@@ -939,9 +939,6 @@ func (c *Credentials) BootstrapCcesAws(clusterName, adminEmail, adminPassword, m
 	config["cloudStorageLocation"].(map[string]interface{})["awsStorageConfig"] = map[string]string{}
 	config["cloudStorageLocation"].(map[string]interface{})["awsStorageConfig"].(map[string]string)["bucketName"] = bucketName
 
-	fmt.Println(config)
-	fmt.Printf("%#v\n", config)
-
 	currentBootstrapStatus, err := c.ClusterBootstrapStatus(httpTimeout)
 	if err != nil {
 		return nil, err
@@ -1032,9 +1029,6 @@ func (c *Credentials) BootstrapCcesAzure(clusterName, adminEmail, adminPassword,
 	config["cloudStorageLocation"].(map[string]interface{})["azureStorageConfig"] = map[string]string{}
 	config["cloudStorageLocation"].(map[string]interface{})["azureStorageConfig"].(map[string]string)["connectionString"] = connectionString
 	config["cloudStorageLocation"].(map[string]interface{})["azureStorageConfig"].(map[string]string)["containerName"] = containerName
-
-	fmt.Println(config)
-	fmt.Printf("%#v\n", config)
 
 	currentBootstrapStatus, err := c.ClusterBootstrapStatus(httpTimeout)
 	if err != nil {

--- a/rubrikcdm/cluster.go
+++ b/rubrikcdm/cluster.go
@@ -815,7 +815,7 @@ func (c *Credentials) AddvCenterWithCert(vCenterIP, vCenterUsername, vCenterPass
 //	The full API response for POST /internal/cluster/me/bootstrap?request_id={requestID} (waitForCompletion is set to true)
 //
 //	The full API response for POST /internal/cluster/me/bootstrap (waitForCompletion is set to false)
-func (c *Credentials) Bootstrap(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask string, dnsSearchDomains, dnsNameServers, ntpServers []string, nodeConfig map[string]string, enableEncryption, waitForCompletion bool, timeout ...int) (interface{}, error) {
+func (c *Credentials) Bootstrap(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask string, dnsSearchDomains []string, dnsNameServers []string, ntpServers map[string]interface{}, nodeConfig map[string]string, enableEncryption, waitForCompletion bool, timeout ...int) (interface{}, error) {
 
 	httpTimeout := httpTimeout(timeout)
 
@@ -833,7 +833,30 @@ func (c *Credentials) Bootstrap(clusterName, adminEmail, adminPassword, manageme
 	config["name"] = clusterName
 	config["dnsNameservers"] = dnsNameServers
 	config["dnsSearchDomains"] = dnsSearchDomains
-	config["ntpServers"] = ntpServers
+
+	ntpServerConfigs := []interface{}{}
+	for _, ntpServer := range ntpServers {
+		server := ntpServer.(map[string]interface{})
+		ntpConfig := map[string]interface{}{}
+		if server["keyId"] != nil {
+			symmetricKey := map[string]interface{}{
+				"keyId":   server["keyId"],
+				"key":     server["key"],
+				"keyType": server["keyType"],
+			}
+			ntpConfig = map[string]interface{}{
+				"server":       server["IP"],
+				"symmetricKey": symmetricKey,
+			}
+		} else {
+			ntpConfig = map[string]interface{}{
+				"server": server["IP"],
+			}
+		}
+
+		ntpServerConfigs = append(ntpServerConfigs, ntpConfig)
+	}
+	config["ntpServerConfigs"] = ntpServerConfigs
 
 	config["adminUserInfo"] = map[string]string{}
 	config["adminUserInfo"].(map[string]string)["password"] = adminPassword
@@ -901,7 +924,7 @@ func (c *Credentials) Bootstrap(clusterName, adminEmail, adminPassword, manageme
 //	The full API response for POST /internal/cluster/me/bootstrap?request_id={requestID} (waitForCompletion is set to true)
 //
 //	The full API response for POST /internal/cluster/me/bootstrap (waitForCompletion is set to false)
-func (c *Credentials) BootstrapCcesAws(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask string, dnsSearchDomains, dnsNameServers, ntpServers []string, nodeConfig map[string]string, enableEncryption bool, bucketName string, waitForCompletion bool, timeout ...int) (interface{}, error) {
+func (c *Credentials) BootstrapCcesAws(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask string, dnsSearchDomains []string, dnsNameServers []string, ntpServers map[string]interface{}, nodeConfig map[string]string, enableEncryption bool, bucketName string, waitForCompletion bool, timeout ...int) (interface{}, error) {
 
 	httpTimeout := httpTimeout(timeout)
 
@@ -919,7 +942,30 @@ func (c *Credentials) BootstrapCcesAws(clusterName, adminEmail, adminPassword, m
 	config["name"] = clusterName
 	config["dnsNameservers"] = dnsNameServers
 	config["dnsSearchDomains"] = dnsSearchDomains
-	config["ntpServers"] = ntpServers
+
+	ntpServerConfigs := []interface{}{}
+	for _, ntpServer := range ntpServers {
+		server := ntpServer.(map[string]interface{})
+		ntpConfig := map[string]interface{}{}
+		if server["keyId"] != nil {
+			symmetricKey := map[string]interface{}{
+				"keyId":   server["keyId"],
+				"key":     server["key"],
+				"keyType": server["keyType"],
+			}
+			ntpConfig = map[string]interface{}{
+				"server":       server["IP"],
+				"symmetricKey": symmetricKey,
+			}
+		} else {
+			ntpConfig = map[string]interface{}{
+				"server": server["IP"],
+			}
+		}
+
+		ntpServerConfigs = append(ntpServerConfigs, ntpConfig)
+	}
+	config["ntpServerConfigs"] = ntpServerConfigs
 
 	config["adminUserInfo"] = map[string]string{}
 	config["adminUserInfo"].(map[string]string)["password"] = adminPassword
@@ -991,7 +1037,7 @@ func (c *Credentials) BootstrapCcesAws(clusterName, adminEmail, adminPassword, m
 //	The full API response for POST /internal/cluster/me/bootstrap?request_id={requestID} (waitForCompletion is set to true)
 //
 //	The full API response for POST /internal/cluster/me/bootstrap (waitForCompletion is set to false)
-func (c *Credentials) BootstrapCcesAzure(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask string, dnsSearchDomains, dnsNameServers, ntpServers []string, nodeConfig map[string]string, enableEncryption bool, connectionString string, containerName string, waitForCompletion bool, timeout ...int) (interface{}, error) {
+func (c *Credentials) BootstrapCcesAzure(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask string, dnsSearchDomains []string, dnsNameServers []string, ntpServers map[string]interface{}, nodeConfig map[string]string, enableEncryption bool, connectionString string, containerName string, waitForCompletion bool, timeout ...int) (interface{}, error) {
 
 	httpTimeout := httpTimeout(timeout)
 
@@ -1009,7 +1055,30 @@ func (c *Credentials) BootstrapCcesAzure(clusterName, adminEmail, adminPassword,
 	config["name"] = clusterName
 	config["dnsNameservers"] = dnsNameServers
 	config["dnsSearchDomains"] = dnsSearchDomains
-	config["ntpServers"] = ntpServers
+
+	ntpServerConfigs := []interface{}{}
+	for _, ntpServer := range ntpServers {
+		server := ntpServer.(map[string]interface{})
+		ntpConfig := map[string]interface{}{}
+		if server["keyId"] != nil {
+			symmetricKey := map[string]interface{}{
+				"keyId":   server["keyId"],
+				"key":     server["key"],
+				"keyType": server["keyType"],
+			}
+			ntpConfig = map[string]interface{}{
+				"server":       server["IP"],
+				"symmetricKey": symmetricKey,
+			}
+		} else {
+			ntpConfig = map[string]interface{}{
+				"server": server["IP"],
+			}
+		}
+
+		ntpServerConfigs = append(ntpServerConfigs, ntpConfig)
+	}
+	config["ntpServerConfigs"] = ntpServerConfigs
 
 	config["adminUserInfo"] = map[string]string{}
 	config["adminUserInfo"].(map[string]string)["password"] = adminPassword

--- a/rubrikcdm/examples_test.go
+++ b/rubrikcdm/examples_test.go
@@ -333,6 +333,7 @@ func ExampleCredentials_BootstrapAws() {
 	enableEncryption := false // set to false for a Cloud Cluster
 	bucketName := "s3-bucket-for-cces-aws"
 	waitForCompletion := true
+	enableEncryption := false // set to false for a Cloud Cluster
 
 	nodeConfig := map[string]string{}
 	nodeConfig["CCESAWSNODE1"] = bootstrapNode
@@ -362,6 +363,7 @@ func ExampleCredentials_BootstrapAzure() {
 	enableEncryption := false // set to false for a Cloud Cluster
 	connectionString := "DefaultEndpointsProtocol=https;AccountName=storageaccountforccesazuregosdk;AccountKey=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890abcdefghijklm==;EndpointSuffix=core.windows.net"
 	containerName := "container-for-cces-azure-gosdk"
+	enableEncryption := false // set to false for a Cloud Cluster
 	waitForCompletion := true
 
 	nodeConfig := map[string]string{}

--- a/rubrikcdm/examples_test.go
+++ b/rubrikcdm/examples_test.go
@@ -300,7 +300,48 @@ func ExampleCredentials_Bootstrap() {
 	managementSubnetMask := "255.255.255.0"
 	dnsSearchDomain := []string{"rubrikgosdk.lab"}
 	dnsNameServers := []string{"192.168.100.5", "192.168.100.6"}
-	ntpServers := []string{"192.168.100.5", "192.168.100.6"}
+	ntpServers := map[string]interface{}{}
+	ntpServers["ntpServer1"] = map[string]interface{}{}
+	ntpServers["ntpServer1"].(map[string]interface{})["IP"] = "192.168.100.5"
+	ntpServers["ntpServer2"] = map[string]interface{}{}
+	ntpServers["ntpServer2"].(map[string]interface{})["IP"] = "192.168.100.6"	enableEncryption := true // set to false for a Cloud Cluster
+	waitForCompletion := true
+
+	nodeConfig := map[string]string{}
+	nodeConfig["RVM1234567890"] = bootstrapNode
+	nodeConfig["RVM1234567891"] = "192.168.101.101"
+	nodeConfig["RVM1234567892"] = "192.168.101.102"
+	nodeConfig["RVM1234567893"] = "192.168.101.103"
+
+	bootstrap, err := rubrik.Bootstrap(clusterName, adminEmail, adminPassword, managementGateway, managementSubnetMask, dnsSearchDomain, dnsNameServers, ntpServers, nodeConfig, enableEncryption, waitForCompletion)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleCredentials_Bootstrap_with_Secure_NTP() {
+
+	bootstrapNode := "192.168.101.100"
+	rubrik := rubrikcdm.Connect(bootstrapNode, "", "")
+
+	clusterName := "Go-SDK"
+	adminEmail := "gosdk@rubrikgosdk.lab"
+	adminPassword := "RubrikGoSDK"
+	managementGateway := "192.168.101.1"
+	managementSubnetMask := "255.255.255.0"
+	dnsSearchDomain := []string{"rubrikgosdk.lab"}
+	dnsNameServers := []string{"192.168.100.5", "192.168.100.6"}
+	ntpServers := map[string]interface{}{}
+	ntpServers["ntpServer1"] = map[string]interface{}{}
+	ntpServers["ntpServer1"].(map[string]interface{})["IP"] = "192.168.100.5"
+	ntpServers["ntpServer1"].(map[string]interface{})["key"] = "key-material-for-ntpserver-1"
+	ntpServers["ntpServer1"].(map[string]interface{})["keyId"] = 0
+	ntpServers["ntpServer1"].(map[string]interface{})["keyType"] = "MD5"
+	ntpServers["ntpServer2"] = map[string]interface{}{}
+	ntpServers["ntpServer2"].(map[string]interface{})["IP"] = "192.168.100.6"
+	ntpServers["ntpServer2"].(map[string]interface{})["keyId"] = 1
+	ntpServers["ntpServer2"].(map[string]interface{})["key"] = "key-material-for-ntpserver-2"
+	ntpServers["ntpServer2"].(map[string]interface{})["keyType"] = "SHA1"
 	enableEncryption := true // set to false for a Cloud Cluster
 	waitForCompletion := true
 
@@ -329,8 +370,11 @@ func ExampleCredentials_BootstrapAws() {
 	managementSubnetMask := "255.255.255.0"
 	dnsSearchDomain := []string{"rubrikgosdk.lab"}
 	dnsNameServers := []string{"192.168.100.5", "192.168.100.6"}
-	ntpServers := []string{"192.168.100.5", "192.168.100.6"}
-	enableEncryption := false // set to false for a Cloud Cluster
+	ntpServers := map[string]interface{}{}
+	ntpServers["ntpServer1"] = map[string]interface{}{}
+	ntpServers["ntpServer1"].(map[string]interface{})["IP"] = "192.168.100.5"
+	ntpServers["ntpServer2"] = map[string]interface{}{}
+	ntpServers["ntpServer2"].(map[string]interface{})["IP"] = "192.168.100.6"	
 	bucketName := "s3-bucket-for-cces-aws"
 	waitForCompletion := true
 	enableEncryption := false // set to false for a Cloud Cluster
@@ -359,8 +403,11 @@ func ExampleCredentials_BootstrapAzure() {
 	managementSubnetMask := "255.255.255.0"
 	dnsSearchDomain := []string{"rubrikgosdk.lab"}
 	dnsNameServers := []string{"192.168.100.5", "192.168.100.6"}
-	ntpServers := []string{"192.168.100.5", "192.168.100.6"}
-	enableEncryption := false // set to false for a Cloud Cluster
+	ntpServers := map[string]interface{}{}
+	ntpServers["ntpServer1"] = map[string]interface{}{}
+	ntpServers["ntpServer1"].(map[string]interface{})["IP"] = "192.168.100.5"
+	ntpServers["ntpServer2"] = map[string]interface{}{}
+	ntpServers["ntpServer2"].(map[string]interface{})["IP"] = "192.168.100.6"
 	connectionString := "DefaultEndpointsProtocol=https;AccountName=storageaccountforccesazuregosdk;AccountKey=abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890abcdefghijklm==;EndpointSuffix=core.windows.net"
 	containerName := "container-for-cces-azure-gosdk"
 	enableEncryption := false // set to false for a Cloud Cluster
@@ -420,6 +467,7 @@ func ExampleCredentials_RegisterCluster() {
 	}
 }
 
+// NOTE: This code is broken for releases of Rubrik CDM v5.0 and later.
 func ExampleCredentials_ConfigureNTP() {
 	rubrik, err := rubrikcdm.ConnectEnv()
 	if err != nil {


### PR DESCRIPTION
# Description

This PR adds the ability to bootstrap CCES clusters.

This PR fixes issues where bootstrap will not properly set the NTP server. This was due to secure NTP settings being added to CDM v5.0. 

## Related Issue

Fixes #58 
Fixes #59 

## Motivation and Context

See the description.

## How Has This Been Tested?

Bootstrapped numerous CCES clusters on AWS.

## Screenshots (if appropriate):

None

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-go/blob/master/CONTRIBUTING.md)** document.
- [X] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
