### PR TITLE
Added retry on connection errors during bootstrap

### DIFF
--- a/rubrikcdm/cluster.go
+++ b/rubrikcdm/cluster.go
@@ -178,6 +178,10 @@ func (c *Credentials) ClusterBootstrapStatus(timeout ...int) (bool, error) {
 				if numberOfAttempts == 24 {
 					return false, err
 				}
+			} else if strings.Contains(err.Error(), "Connection refused") || strings.Contains(err.Error(), "Internal Server Error") {
+				if numberOfAttempts == 24 {
+					return false, err
+				}
 			} else if strings.Contains(err.Error(), "Unable to establish a connection") {
 
 				if numberOfAttempts == 6 {


### PR DESCRIPTION
# Description

Fixed Internal Server Error 500 during bootstrapping by retrying bootstrap status. 

## Related Issue

Fixes #67

## Motivation and Context

Fix needed for issue rubrikinc/terraform-aws-rubrik-cloud-cluster-elastic-storage#8

## How Has This Been Tested?

Built a new test provider for [terraform-provider-rubrik](https://github.com/rubrikinc/terraform-provider-rubrik) with this fix and had the original reporter deploy CCES several times. The origianl reporter reported success on each try.  

## Screenshots (if appropriate):

None

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/rubrik-sdk-for-go/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
